### PR TITLE
Transit gateway

### DIFF
--- a/aws-ec2-transitgateway/docs/README.md
+++ b/aws-ec2-transitgateway/docs/README.md
@@ -131,4 +131,3 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### Id
 
 Returns the <code>Id</code> value.
-

--- a/aws-ec2-transitgateway/docs/tag.md
+++ b/aws-ec2-transitgateway/docs/tag.md
@@ -37,4 +37,3 @@ _Required_: Yes
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-


### PR DESCRIPTION
* TransitGateway had been previously removed to clear the master branch for publishing of the Mcast Resources. 
* Adding the TGW Resource back to the pipeline. 
* Adding IncorrectStateException to the exceptionMapper

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
