### PR TITLE
bug fix in multicastAssociation

### DIFF
--- a/aws-ec2-transitgatewaymulticastdomainassociation/src/main/java/software/amazon/ec2/transitgatewaymulticastdomainassociation/workflow/create/Create.java
+++ b/aws-ec2-transitgatewaymulticastdomainassociation/src/main/java/software/amazon/ec2/transitgatewaymulticastdomainassociation/workflow/create/Create.java
@@ -62,8 +62,9 @@ public class Create {
         CallbackContext context
     ) {
 
-        String currentState = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).simpleRequest(model).getState();
-        return TransitGatewayMulitcastDomainAssociationState.ASSOCIATED.toString().equals(currentState);
+        ResourceModel currentResourceModel = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).simpleRequest(model);
+        if(currentResourceModel == null) return false;
+        else return TransitGatewayMulitcastDomainAssociationState.ASSOCIATED.toString().equals(currentResourceModel.getState());
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext>  handleError(AssociateTransitGatewayMulticastDomainRequest awsRequest, Exception exception, ProxyClient<Ec2Client> client, ResourceModel model, CallbackContext context) {


### PR DESCRIPTION
* In the create workflow, the read request to check the state of the McastAssociation was trying to read before the Resource actually got created. 
* Added a check to ensure that resource is non-null before we do a read request. 
* This should fix the stuck canaries. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
