### PR TITLE
Fixes eventual consistency bug

### DIFF
--- a/aws-ec2-transitgatewaypeeringattachment/src/main/java/software/amazon/ec2/transitgatewaypeeringattachment/CreateHandler.java
+++ b/aws-ec2-transitgatewaypeeringattachment/src/main/java/software/amazon/ec2/transitgatewaypeeringattachment/CreateHandler.java
@@ -1,7 +1,6 @@
 package software.amazon.ec2.transitgatewaypeeringattachment;
 
 import software.amazon.ec2.transitgatewaypeeringattachment.workflow.create.Create;
-import software.amazon.ec2.transitgatewaypeeringattachment.workflow.read.Read;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.cloudformation.proxy.*;
 
@@ -14,7 +13,6 @@ public class CreateHandler extends BaseHandlerStd {
         final ProxyClient<Ec2Client> proxyClient,
         final Logger logger) {
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-            .then(new Create(proxy, request, callbackContext, proxyClient, logger)::run)
-            .then(new Read(proxy, request, callbackContext, proxyClient, logger)::run);
+            .then(new Create(proxy, request, callbackContext, proxyClient, logger)::run);
     }
 }

--- a/aws-ec2-transitgatewaypeeringattachment/src/main/java/software/amazon/ec2/transitgatewaypeeringattachment/workflow/create/Create.java
+++ b/aws-ec2-transitgatewaypeeringattachment/src/main/java/software/amazon/ec2/transitgatewaypeeringattachment/workflow/create/Create.java
@@ -1,14 +1,15 @@
 package software.amazon.ec2.transitgatewaypeeringattachment.workflow.create;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ec2.model.*;
 import software.amazon.ec2.transitgatewaypeeringattachment.CallbackContext;
+import software.amazon.ec2.transitgatewaypeeringattachment.PeeringAttachmentStatus;
 import software.amazon.ec2.transitgatewaypeeringattachment.ResourceModel;
 import software.amazon.ec2.transitgatewaypeeringattachment.workflow.ExceptionMapper;
 import software.amazon.ec2.transitgatewaypeeringattachment.workflow.TagUtils;
 import software.amazon.ec2.transitgatewaypeeringattachment.workflow.read.Read;
 import software.amazon.awssdk.services.ec2.Ec2Client;
-import software.amazon.awssdk.services.ec2.model.CreateTransitGatewayPeeringAttachmentRequest;
-import software.amazon.awssdk.services.ec2.model.CreateTransitGatewayPeeringAttachmentResponse;
-import software.amazon.awssdk.services.ec2.model.TransitGatewayAttachmentState;
 import software.amazon.cloudformation.proxy.*;
 
 public class Create {
@@ -18,6 +19,7 @@ public class Create {
     ProxyClient<Ec2Client> client;
     Logger logger;
     ProgressEvent<ResourceModel, CallbackContext>  progress;
+    ResourceModel stableResponse;
 
     public Create(
         AmazonWebServicesClientProxy proxy,
@@ -39,7 +41,7 @@ public class Create {
             .makeServiceCall(this::makeServiceCall)
             .stabilize(this::stabilize)
             .handleError(this::handleError)
-            .progress();
+            .done(this::done);
     }
 
     private CreateTransitGatewayPeeringAttachmentRequest translateModelToRequest(ResourceModel model) {
@@ -64,11 +66,26 @@ public class Create {
         CallbackContext context
     ) {
         model.setTransitGatewayAttachmentId(awsResponse.transitGatewayPeeringAttachment().transitGatewayAttachmentId());
-        String currentState = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).simpleRequest(model).getState();
-        return (TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString().equals(currentState) || TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentState));
+        ResourceModel currentResourceModel = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).simpleRequest(model);
+        if(currentResourceModel == null) return false;
+        boolean isStable = (TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString().equals(currentResourceModel.getState()) || TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentResourceModel.getState()));
+        if (isStable) {
+            this.stableResponse = currentResourceModel;
+        }
+        return isStable;
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext>  handleError(CreateTransitGatewayPeeringAttachmentRequest awsRequest, Exception exception, ProxyClient<Ec2Client> client, ResourceModel model, CallbackContext context) {
         return ProgressEvent.defaultFailureHandler(exception, ExceptionMapper.mapToHandlerErrorCode(exception));
+    }
+
+    private  ProgressEvent<ResourceModel, CallbackContext> done(CreateTransitGatewayPeeringAttachmentResponse response) {
+        ResourceModel model = this.stableResponse;
+        if(model == null || model.getState().equals(TransitGatewayAttachmentState.DELETED.toString())) {
+            AwsServiceException emptyResponseException = AwsServiceException.builder().awsErrorDetails(AwsErrorDetails.builder().errorCode("NotFound").errorMessage("Not Found").build()).build();
+            return ProgressEvent.defaultFailureHandler(emptyResponseException, HandlerErrorCode.NotFound);
+        } else {
+            return ProgressEvent.defaultSuccessHandler(model);
+        }
     }
 }


### PR DESCRIPTION
- No longer calls read after create to avoid read returning empty due to the eventually consistent nature of describe calls.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
