### PR TITLE
tgwAttachment resource migration

### DIFF
--- a/aws-ec2-transitgatewayattachment/.rpdk-config
+++ b/aws-ec2-transitgatewayattachment/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::EC2::TransitGatewayAttachment",
     "language": "java",
     "runtime": "java8",
@@ -18,5 +19,6 @@
         ],
         "codegen_template_path": "default",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "com.aws.ec2.transitgatewayattachment.HandlerWrapperExecutable"
 }

--- a/aws-ec2-transitgatewayattachment/inputs/inputs_1_create.json
+++ b/aws-ec2-transitgatewayattachment/inputs/inputs_1_create.json
@@ -1,9 +1,8 @@
 {
-  "TransitGatewayId": "tgw-02c783c4653c2bdad",
-  "VpcId": "vpc-0e32b4e0c1ca43f43",
+  "TransitGatewayId": "tgw-0d735d3b3d5232cc0",
+  "VpcId": "vpc-0ecbe65983beb59fc",
   "SubnetIds": [
-    "subnet-0d2d2e34a920cd263",
-    "subnet-0c1dcbe37e3db157b"
+    "subnet-0d9c1092bec4a817c"
   ],
   "Tags": [
     {


### PR DESCRIPTION
*Description of changes:*

Removed update handler for AWS::EC2::TransitGatewayAttachment to keep the resource consistent with the self-service version. Will add update/modify support once resource is migrated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
