### PR TITLE
Adding tagging settings to rtb propagation

### DIFF
--- a/aws-ec2-transitgatewayroutetablepropagation/aws-ec2-transitgatewayroutetablepropagation.json
+++ b/aws-ec2-transitgatewayroutetablepropagation/aws-ec2-transitgatewayroutetablepropagation.json
@@ -24,6 +24,12 @@
       "type": "string"
     }
   },
+  "tagging": {
+    "taggable": false,
+    "tagOnCreate": false,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false
+  },
   "definitions": {},
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
*Issue #, if available:*

```
java.lang.AssertionError: [Assert that Readiness Review status is NOT equal to FAILED] [FAIL] - Contract Tests result is: 'FAILED',  [FAIL] - Metadata key: 'tagging' not present in schema,  [SKIP] - Canaries not found, please register type canaries and retry the registration to re-run readiness review
```

*Description of changes:*

I added tagging settings to rtb propagation so that this test would pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
