### PR TITLE
Allows VPC attachments to terminate in pendingAcceptance.

### DIFF
--- a/aws-ec2-transitgatewayattachment/src/main/java/com/aws/ec2/transitgatewayattachment/workflow/create/Create.java
+++ b/aws-ec2-transitgatewayattachment/src/main/java/com/aws/ec2/transitgatewayattachment/workflow/create/Create.java
@@ -109,7 +109,10 @@ public class Create {
             currentResourceModel = null;
             currentState = null;
         }
-        boolean isStable = currentState != null && currentResourceModel != null && TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentState);
+        boolean isStable = currentState != null && currentResourceModel != null && (
+                TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString().equals(currentState)
+                        || TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentState)
+        );
         if (isStable) {
             this.stableResponse = currentResourceModel;
         }

--- a/aws-ec2-transitgatewayattachment/src/main/java/com/aws/ec2/transitgatewayattachment/workflow/read/ValidateCurrentState.java
+++ b/aws-ec2-transitgatewayattachment/src/main/java/com/aws/ec2/transitgatewayattachment/workflow/read/ValidateCurrentState.java
@@ -28,6 +28,7 @@ public class ValidateCurrentState extends ValidateCurrentStateBase {
     protected List<String> validStates() {
         List<String> list = new ArrayList<>();
         list.add(TransitGatewayAttachmentState.AVAILABLE.toString());
+        list.add(TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString());
         list.add(TransitGatewayAttachmentState.DELETING.toString());
         list.add(TransitGatewayAttachmentState.MODIFYING.toString());
         list.add(TransitGatewayAttachmentState.PENDING.toString());

--- a/aws-ec2-transitgatewayattachment/src/test/java/com/aws/ec2/transitgatewayattachment/CreateHandlerTest.java
+++ b/aws-ec2-transitgatewayattachment/src/test/java/com/aws/ec2/transitgatewayattachment/CreateHandlerTest.java
@@ -66,6 +66,19 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_SuccessForPendingAcceptance() {
+        final List<Tag> newTags = new ArrayList<>();
+        final String state = "pendingAcceptance";
+        ResourceModel model = MOCKS.model(newTags, state);
+
+        when(proxyClient.client().createTransitGatewayVpcAttachment(any(CreateTransitGatewayVpcAttachmentRequest.class))).thenReturn(MOCKS.createResponse(newTags, state));
+        when(proxyClient.client().describeTransitGatewayVpcAttachments(any(DescribeTransitGatewayVpcAttachmentsRequest.class))).thenReturn(MOCKS.emptyReadResponse()).thenReturn(MOCKS.describeResponse(newTags, state));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, MOCKS.request(model), new CallbackContext(), proxyClient, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    }
+
+    @Test
     public void handleRequest_Duplicates() {
         when(proxyClient.client().describeTransitGatewayVpcAttachments(any(DescribeTransitGatewayVpcAttachmentsRequest.class))).thenReturn(MOCKS.describeResponse());
 

--- a/aws-ec2-transitgatewayvpcattachment/src/main/java/com/aws/ec2/transitgatewayvpcattachment/workflow/create/Create.java
+++ b/aws-ec2-transitgatewayvpcattachment/src/main/java/com/aws/ec2/transitgatewayvpcattachment/workflow/create/Create.java
@@ -48,7 +48,7 @@ public class Create {
     private CreateTransitGatewayVpcAttachmentRequest translateModelToRequest(ResourceModel model) {
         List<Tag> tags = (model.getTags() != null) ? com.aws.ec2.transitgatewayvpcattachment.workflow.TagUtils.mergeResourceModelAndStackTags(model.getTags(), this.request.getDesiredResourceTags())
                 : new ArrayList<Tag>();
-        logger.log("requset parameters"+model.getSubnetIds()+","+model.getTransitGatewayId()+","+model.getVpcId()+"+"+TagUtils.cfnTagsToSdkTagSpecifications(tags));
+        logger.log("Request parameters"+model.getSubnetIds()+","+model.getTransitGatewayId()+","+model.getVpcId()+"+"+TagUtils.cfnTagsToSdkTagSpecifications(tags));
 
         return CreateTransitGatewayVpcAttachmentRequest.builder()
                     .subnetIds(model.getSubnetIds())
@@ -98,7 +98,7 @@ public class Create {
         String currentState;
         ResourceModel currentResourceModel;
         try {
-	    currentState = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).stateRequest(model).toString();
+            currentState = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).stateRequest(model).toString();
             currentResourceModel = new Read(this.proxy, this.request, this.callbackContext, this.client, this.logger).simpleRequest(model);
         } catch (Exception e) {
             // If we got this far, this means CREATION was successful, and any failures to READ are most
@@ -107,7 +107,8 @@ public class Create {
             currentResourceModel = null;
             currentState = null;
         }
-        boolean isStable = currentState != null && currentResourceModel != null && TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentState);
+        boolean isStable = TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString().equals(currentState)
+                        || TransitGatewayAttachmentState.AVAILABLE.toString().equals(currentState);
         if (isStable) {
             this.stableResponse = currentResourceModel;
         }

--- a/aws-ec2-transitgatewayvpcattachment/src/main/java/com/aws/ec2/transitgatewayvpcattachment/workflow/read/ValidateCurrentState.java
+++ b/aws-ec2-transitgatewayvpcattachment/src/main/java/com/aws/ec2/transitgatewayvpcattachment/workflow/read/ValidateCurrentState.java
@@ -28,6 +28,7 @@ public class ValidateCurrentState extends ValidateCurrentStateBase {
     protected List<String> validStates() {
         List<String> list = new ArrayList<>();
         list.add(TransitGatewayAttachmentState.AVAILABLE.toString());
+        list.add(TransitGatewayAttachmentState.PENDING_ACCEPTANCE.toString());
         list.add(TransitGatewayAttachmentState.DELETING.toString());
         list.add(TransitGatewayAttachmentState.MODIFYING.toString());
         list.add(TransitGatewayAttachmentState.PENDING.toString());

--- a/aws-ec2-transitgatewayvpcattachment/src/test/java/com/aws/ec2/transitgatewayvpcattachment/CreateHandlerTest.java
+++ b/aws-ec2-transitgatewayvpcattachment/src/test/java/com/aws/ec2/transitgatewayvpcattachment/CreateHandlerTest.java
@@ -48,7 +48,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         ResourceModel model = MOCKS.model(newTags);
 
         when(proxyClient.client().createTransitGatewayVpcAttachment(any(CreateTransitGatewayVpcAttachmentRequest.class))).thenReturn(MOCKS.createResponse(newTags));
-	 when(proxyClient.client().describeTransitGatewayVpcAttachments(any(DescribeTransitGatewayVpcAttachmentsRequest.class))).thenReturn(MOCKS.emptyReadResponse()).thenReturn(MOCKS.describeResponse(newTags));
+	    when(proxyClient.client().describeTransitGatewayVpcAttachments(any(DescribeTransitGatewayVpcAttachmentsRequest.class))).thenReturn(MOCKS.emptyReadResponse()).thenReturn(MOCKS.describeResponse(newTags));
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, MOCKS.request(model), new CallbackContext(), proxyClient, logger);
 
@@ -61,6 +61,19 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SuccessForPendingAcceptance() {
+        final List<Tag> newTags = new ArrayList<>();
+        final String state = "pendingAcceptance";
+        ResourceModel model = MOCKS.model(newTags, state);
+
+        when(proxyClient.client().createTransitGatewayVpcAttachment(any(CreateTransitGatewayVpcAttachmentRequest.class))).thenReturn(MOCKS.createResponse(newTags));
+        when(proxyClient.client().describeTransitGatewayVpcAttachments(any(DescribeTransitGatewayVpcAttachmentsRequest.class))).thenReturn(MOCKS.emptyReadResponse()).thenReturn(MOCKS.describeResponse(newTags, state));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, MOCKS.request(model), new CallbackContext(), proxyClient, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When customers create VPC attachments that go to Pending Acceptance via CFN, the resource currently fails. This is fixed to match the behavior of Peering attachments and instead succeed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
