### PR TITLE
Removing memberType from mcastGroupSource & sourceType from mcastGrou…

### DIFF
--- a/aws-ec2-transitgatewaymulticastgroupmember/aws-ec2-transitgatewaymulticastgroupmember.json
+++ b/aws-ec2-transitgatewaymulticastgroupmember/aws-ec2-transitgatewaymulticastgroupmember.json
@@ -61,7 +61,6 @@
     "/properties/GroupSource",
     "/properties/GroupMember",
     "/properties/MemberType",
-    "/properties/SourceType",
     "/properties/TransitGatewayAttachmentId"
   ],
   "createOnlyProperties": [

--- a/aws-ec2-transitgatewaymulticastgroupsource/aws-ec2-transitgatewaymulticastgroupsource.json
+++ b/aws-ec2-transitgatewaymulticastgroupsource/aws-ec2-transitgatewaymulticastgroupsource.json
@@ -60,7 +60,6 @@
     "/properties/ResourceType",
     "/properties/GroupSource",
     "/properties/GroupMember",
-    "/properties/MemberType",
     "/properties/SourceType",
     "/properties/TransitGatewayAttachmentId"
   ],


### PR DESCRIPTION
### Conform with the contract test v2 rules
Since these resource TgwMcastGroupSource & TgwMcastGroupMember are based on a common resource TgwMcastGroup, each resource has some properties which may not be necessarily displayed in each read request based on the resource type (Member or Source). But according to the contract test v2, each readOnly property needs to be displayed in the readRequest. Making the following changes to conform with the contract test consistency standards. 
- Removing the property sourceType from under readOnly properties in mcastGroupMember to conform with the contract test v2 rules. 
- Removing the property memberType from under readOnly properties in mcastGroupSource  to conform with the contract test v2 rules.



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
